### PR TITLE
Fix image drag and dropping (banish webp posters)

### DIFF
--- a/client/posts/posting/drop.ts
+++ b/client/posts/posting/drop.ts
@@ -34,7 +34,7 @@ async function onDrop(e: DragEvent) {
 	}
 
 	let file: File;
-	if (files.length) {
+	if (files.length && !url) {
 		file = files[0];
 	} else if (url) {
 		// Fetch file from link


### PR DESCRIPTION
When an image is dropped, files array is actually populated with the image.

This addition of 8 characters kills the webp poster.

Tested on
Chrome versions 107.0.5304.106, 108.0.5359.125
Firefox 108.0.1 (64-bit, Normal Edition), 109.0b6 (64-bit, Developer Edition)