### PR TITLE
Fix alt shortcuts on macOS Firefox

### DIFF
--- a/client/ui/keyboard.ts
+++ b/client/ui/keyboard.ts
@@ -32,7 +32,7 @@ function handleShortcut(event: KeyboardEvent) {
 		}
 	}
 
-	if (event.altKey && !altGr) {
+        if (event.altKey && (!altGr || navigator.platform == "MacIntel")) {
 		caught = true
 
 		switch (event.which) {


### PR DESCRIPTION
Firefox sets AltGraph when the option key is pressed on macOS.