### PR TITLE
retry images less aggressively

### DIFF
--- a/client/posts/posting/image.ts
+++ b/client/posts/posting/image.ts
@@ -1,32 +1,81 @@
+
+let consecutiveFailures = 0;
+const pendingRetries: Set<HTMLImageElement> = new Set()
+const TICK_BASE = 2000;
+const TICK_MAX = 60 * 1000;
+
 // Reload image if error
 // Handle event if image error
 function onImageErr(e: Event) {
     const el = (e.target as HTMLImageElement)
 
     if (el.tagName !== "IMG"
-        || (el.complete && el.naturalWidth !== 0)
-        || el.getAttribute("data-scheduled-retry")) {
+        || (el.complete && el.naturalWidth !== 0)) {
         return
     }
 
     e.stopPropagation()
     e.preventDefault()
 
-    el.setAttribute("data-scheduled-retry", "1");
-    setTimeout(() => retry(el), 2000);
+    // there were no pending entries we need to start a new timer chain
+    if (pendingRetries.size == 0) {
+        setTimeout(() => tick(), TICK_BASE)
+    }
+
+    el.dataset.scheduledRetry = "pending"
+
+    if (pendingRetries.has(el)) {
+        consecutiveFailures += 1
+        // Set maintains insertion-order. We can use that as a queue.
+        pendingRetries.delete(el)
+        pendingRetries.add(el)
+    } else {
+        pendingRetries.add(el)
+    }
 }
 
-// Retry download
-function retry(el: HTMLImageElement) {
-    if (!document.contains(el) || el.naturalWidth !== 0) {
-        el.removeAttribute("data-scheduled-retry");
-        return;
+function onImageLoad(e: Event) {
+    const el = (e.target as HTMLImageElement)
+
+    if (el.tagName !== "IMG") {
+        return
     }
-    el.src = el.src;
-    setTimeout(() => retry(el), 2000);
+
+    if (pendingRetries.has(el)) {
+        consecutiveFailures = consecutiveFailures / 2
+        pendingRetries.delete(el)
+        delete el.dataset.scheduledRetry
+    }
+}
+
+
+function tick() {
+    for(let el of pendingRetries) {
+        // one reload at a time, to avoid hammering the server
+        if (el.dataset.scheduledRetry === "active") {
+            break
+        }
+        if (el.dataset.scheduledRetry === "pending") {
+            el.dataset.scheduledRetry = "active"
+            el.src = el.src
+            break
+        }
+        // skip detached dom nodes and completed images
+        if (!document.contains(el)
+            || (el.complete && el.naturalWidth !== 0)) {
+            pendingRetries.delete(el)
+        }
+    }
+
+    if (pendingRetries.size > 0) {
+        // slow down refreshing if we're experiencing failures
+        let delay = Math.min(TICK_MAX,  TICK_BASE * Math.pow(2, consecutiveFailures))
+        setTimeout(() => tick(), delay)
+    }
 }
 
 // Bind listeners
 export default () => {
     document.addEventListener("error", onImageErr, true)
+    document.addEventListener("load", onImageLoad, true)
 }


### PR DESCRIPTION
I saw the meguca client doing retries over and over again when the server is slow and thumbnails don't load.
So this retries one image at a time and adds some exponential backoff on top when reloads fail. Overall that should result in a much more sedate reload pace.

I also noticed that a bunch of things are outdated and had to tweak a few bits to get it to build. Would you accept maintenance PRs that update dependencies and things like that?