### PR TITLE
update the link in the info panel

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -241,8 +241,8 @@
 					</a>
 					<br>
 					Source code repository:{% space %}
-					<a href="https://github.com/bakape/meguca" target="_blank">
-						github.com/bakape/meguca
+					<a href="https://github.com/zkm2/shamichan/tree/v6" target="_blank">
+						github.com/zkm2/shamichan/tree/v6
 					</a>
 					<hr>
 					{%s= strings.Replace(conf.FAQ, "\n", "<br>", -1) %}


### PR DESCRIPTION
If you change the default branch in the github settings to `v6` then the link could also go to the repo's main page instead of having to add `/tree/v6`